### PR TITLE
[Repo Assist] buffer: use byte arrays in write_word and write_dword

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -95,20 +95,20 @@ void
 libspectrum_buffer_write_word( libspectrum_buffer *buffer,
                                const libspectrum_word data )
 {
-  libspectrum_word lsb_data;
-  libspectrum_byte* lsb_data_ptr = (libspectrum_byte*)&lsb_data;
-  libspectrum_write_word( &lsb_data_ptr, data );
-  libspectrum_buffer_write( buffer, &lsb_data, sizeof( libspectrum_word ) ) ;
+  libspectrum_byte lsb_data[2];
+  libspectrum_byte *ptr = lsb_data;
+  libspectrum_write_word( &ptr, data );
+  libspectrum_buffer_write( buffer, lsb_data, sizeof( lsb_data ) );
 }
 
 void
 libspectrum_buffer_write_dword( libspectrum_buffer *buffer,
                                 const libspectrum_dword data )
 {
-  libspectrum_dword lsb_data;
-  libspectrum_byte* lsb_data_ptr = (libspectrum_byte*)&lsb_data;
-  libspectrum_write_dword( &lsb_data_ptr, data );
-  libspectrum_buffer_write( buffer, &lsb_data, sizeof( libspectrum_dword ) ) ;
+  libspectrum_byte lsb_data[4];
+  libspectrum_byte *ptr = lsb_data;
+  libspectrum_write_dword( &ptr, data );
+  libspectrum_buffer_write( buffer, lsb_data, sizeof( lsb_data ) );
 }
 
 void


### PR DESCRIPTION
Replace type-punned libspectrum_word/libspectrum_dword locals with properly-typed libspectrum_byte arrays in libspectrum_buffer_write_word and libspectrum_buffer_write_dword.

The previous code cast a word/dword pointer to libspectrum_byte* to feed into libspectrum_write_word/write_dword. While valid in C (accessing object bytes through unsigned char* is defined), using a byte array is cleaner: it removes the explicit cast, avoids any potential aliasing concern, and makes the intended byte-buffer role of the variable explicit.